### PR TITLE
Define server environment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4445,6 +4445,24 @@
 			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
 			"dev": true
 		},
+		"node_modules/cross-env": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+			"integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+			"dev": true,
+			"dependencies": {
+				"cross-spawn": "^7.0.1"
+			},
+			"bin": {
+				"cross-env": "src/bin/cross-env.js",
+				"cross-env-shell": "src/bin/cross-env-shell.js"
+			},
+			"engines": {
+				"node": ">=10.14",
+				"npm": ">=6",
+				"yarn": ">=1"
+			}
+		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -18488,6 +18506,7 @@
 				"@types/uuid": "^8.3.3",
 				"@typescript-eslint/eslint-plugin": "^5.7.0",
 				"@typescript-eslint/parser": "^5.7.0",
+				"cross-env": "^7.0.3",
 				"eslint": "^8.4.1",
 				"eslint-config-airbnb-base": "^15.0.0",
 				"eslint-import-resolver-typescript": "^2.5.0",
@@ -22186,6 +22205,15 @@
 			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
 			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
 			"dev": true
+		},
+		"cross-env": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+			"integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+			"dev": true,
+			"requires": {
+				"cross-spawn": "^7.0.1"
+			}
 		},
 		"cross-spawn": {
 			"version": "7.0.3",
@@ -29829,6 +29857,7 @@
 				"@typescript-eslint/eslint-plugin": "^5.7.0",
 				"@typescript-eslint/parser": "^5.7.0",
 				"cors": "^2.8.5",
+				"cross-env": "^7.0.3",
 				"dotenv": "^10.0.0",
 				"dotenv-expand": "^5.1.0",
 				"eslint": "^8.4.1",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -25,6 +25,7 @@
 				"@types/uuid": "^8.3.3",
 				"@typescript-eslint/eslint-plugin": "^5.7.0",
 				"@typescript-eslint/parser": "^5.7.0",
+				"cross-env": "^7.0.3",
 				"eslint": "^8.4.1",
 				"eslint-config-airbnb-base": "^15.0.0",
 				"eslint-import-resolver-typescript": "^2.5.0",
@@ -1294,6 +1295,24 @@
 			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
 			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
 			"dev": true
+		},
+		"node_modules/cross-env": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+			"integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+			"dev": true,
+			"dependencies": {
+				"cross-spawn": "^7.0.1"
+			},
+			"bin": {
+				"cross-env": "src/bin/cross-env.js",
+				"cross-env-shell": "src/bin/cross-env-shell.js"
+			},
+			"engines": {
+				"node": ">=10.14",
+				"npm": ">=6",
+				"yarn": ">=1"
+			}
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
@@ -5605,6 +5624,15 @@
 			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
 			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
 			"dev": true
+		},
+		"cross-env": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+			"integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+			"dev": true,
+			"requires": {
+				"cross-spawn": "^7.0.1"
+			}
 		},
 		"cross-spawn": {
 			"version": "7.0.3",

--- a/server/package.json
+++ b/server/package.json
@@ -3,8 +3,8 @@
 	"main": "./dist/app.js",
 	"scripts": {
 		"ci": "npm run lint && tsc",
-		"start": "tsc && node ./dist/app.js",
-		"start:dev": "nodemon --exec npx ts-node ./src/app.ts",
+		"start": "cross-env NODE_ENV=production tsc && node ./dist/app.js",
+		"start:dev": "cross-env NODE_ENV=development nodemon --exec npx ts-node ./src/app.ts",
 		"lint": "eslint ./src/ --ext .ts"
 	},
 	"author": "EmJee1",
@@ -27,6 +27,7 @@
 		"@types/uuid": "^8.3.3",
 		"@typescript-eslint/eslint-plugin": "^5.7.0",
 		"@typescript-eslint/parser": "^5.7.0",
+		"cross-env": "^7.0.3",
 		"eslint": "^8.4.1",
 		"eslint-config-airbnb-base": "^15.0.0",
 		"eslint-import-resolver-typescript": "^2.5.0",

--- a/server/src/config/winston.ts
+++ b/server/src/config/winston.ts
@@ -14,7 +14,8 @@ const logger = createLogger({
 	],
 })
 
-// TODO: only load this when NODE_ENV is development
-logger.add(new transports.Console({ format: format.simple() }))
+if (process.env.NODE_ENV === 'development') {
+	logger.add(new transports.Console({ format: format.simple() }))
+}
 
 export default logger


### PR DESCRIPTION
#### Wat doet dit PR

Het voegt de `NODE_ENV` variabele toe aan de environment variables met een waarden van `development` of `production`, afhankelijk van het npm command. Deze value wordt momenteel gebruikt om alleen in development logdata naar de console te schrijven.

#### Hoe test je dit PR

- Check dat de NODE_ENV variabele goed wordt gezet op `process.env.NODE_ENV` afhankelijk van het startcommando.
- Het `npm start` command werkt nog niet door een compileissue, hiervoor staat een ticket [#023](https://trello.com/c/o48XsjRU/23-compiled-starterror-voor-server) open.